### PR TITLE
Can now get list of posts with parsed frontmatter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-svelte": "^2.35.1",
+    "mdsvex": "^0.11.0",
     "postcss": "^8.4.33",
     "prettier": "^3.1.1",
     "prettier-plugin-svelte": "^3.1.2",
@@ -40,6 +41,7 @@
     "@fontsource-variable/jura": "^5.0.18",
     "@fontsource-variable/nunito": "^5.0.17",
     "@fontsource-variable/source-code-pro": "^5.0.17",
-    "lucide-svelte": "^0.306.0"
+    "lucide-svelte": "^0.306.0",
+    "shiki": "^0.14.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   lucide-svelte:
     specifier: ^0.306.0
     version: 0.306.0(svelte@4.2.8)
+  shiki:
+    specifier: ^0.14.7
+    version: 0.14.7
 
 devDependencies:
   '@sveltejs/adapter-auto':
@@ -52,6 +55,9 @@ devDependencies:
   eslint-plugin-svelte:
     specifier: ^2.35.1
     version: 2.35.1(eslint@8.56.0)(svelte@4.2.8)
+  mdsvex:
+    specifier: ^0.11.0
+    version: 0.11.0(svelte@4.2.8)
   postcss:
     specifier: ^8.4.33
     version: 8.4.33
@@ -663,6 +669,10 @@ packages:
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
+  /@types/unist@2.0.10:
+    resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
+    dev: true
+
   /@typescript-eslint/eslint-plugin@6.18.0(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-3lqEvQUdCozi6d1mddWqd+kf8KxmGq2Plzx36BlkjuQe3rSTm/O98cLf0A4uDO+a5N1KD2SeEEl6fW97YHY+6w==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -874,6 +884,10 @@ packages:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
     dev: true
+
+  /ansi-sequence-parser@1.1.1:
+    resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
+    dev: false
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1713,7 +1727,6 @@ packages:
 
   /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-    dev: true
 
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1808,6 +1821,18 @@ packages:
 
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  /mdsvex@0.11.0(svelte@4.2.8):
+    resolution: {integrity: sha512-gJF1s0N2nCmdxcKn8HDn0LKrN8poStqAicp6bBcsKFd/zkUBGLP5e7vnxu+g0pjBbDFOscUyI1mtHz+YK2TCDw==}
+    peerDependencies:
+      svelte: '>=3 <5'
+    dependencies:
+      '@types/unist': 2.0.10
+      prism-svelte: 0.4.7
+      prismjs: 1.29.0
+      svelte: 4.2.8
+      vfile-message: 2.0.4
+    dev: true
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2204,6 +2229,15 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /prism-svelte@0.4.7:
+    resolution: {integrity: sha512-yABh19CYbM24V7aS7TuPYRNMqthxwbvx6FF/Rw920YbyBWO3tnyPIqRMgHuSVsLmuHkkBS1Akyof463FVdkeDQ==}
+    dev: true
+
+  /prismjs@1.29.0:
+    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
+    engines: {node: '>=6'}
+    dev: true
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2331,6 +2365,15 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
     dev: true
+
+  /shiki@0.14.7:
+    resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
+    dependencies:
+      ansi-sequence-parser: 1.1.1
+      jsonc-parser: 3.2.0
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
+    dev: false
 
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2702,6 +2745,12 @@ packages:
     resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
     dev: true
 
+  /unist-util-stringify-position@2.0.3:
+    resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+    dependencies:
+      '@types/unist': 2.0.10
+    dev: true
+
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -2721,6 +2770,13 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
+
+  /vfile-message@2.0.4:
+    resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
+    dependencies:
+      '@types/unist': 2.0.10
+      unist-util-stringify-position: 2.0.3
     dev: true
 
   /vite-node@1.1.3:
@@ -2845,6 +2901,14 @@ packages:
       - supports-color
       - terser
     dev: true
+
+  /vscode-oniguruma@1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
+    dev: false
+
+  /vscode-textmate@8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
+    dev: false
 
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}

--- a/src/lib/postTypes.ts
+++ b/src/lib/postTypes.ts
@@ -1,0 +1,10 @@
+export type Categories = string;
+
+export type Post = {
+  title: string;
+  slug: string;
+  description: string;
+  date: string;
+  categories: Categories[];
+  published: boolean;
+};

--- a/src/posts/hello-world.md
+++ b/src/posts/hello-world.md
@@ -1,0 +1,24 @@
+---
+title: 'Hello world!'
+description: 'A test post to make sure everything is working.'
+date: '2024-01-06'
+categories:
+  - Markdown
+  - Math
+published: true
+---
+
+## Testing...1, 2, 3...1, 2, 3
+
+This is some test post to ensure that things are working as they should.
+
+```rs
+fn getGreeting(name: &str) -> String {
+    format!("Hello there, {}!", name);
+}
+
+fn main() {
+    let name = "Josh";
+    println!("{}", getGreeting(&name));
+}
+```

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,15 @@
+<script lang="ts">
+  export let data;
+</script>
+
 <div class="grow bg-pink-200 font-nunito">
   <h1>Welcome to SvelteKit</h1>
   <p>
     Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation
   </p>
+  <ul>
+    {#each data.posts as post}
+      <li><a href={post.slug}>{post.title}</a></li>
+    {/each}
+  </ul>
 </div>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,0 +1,10 @@
+import type {Post} from '$lib/postTypes';
+import type { PageLoad } from './$types';
+
+type LoadResponse = {
+  posts: Post[]
+}
+
+export const load: PageLoad = async ({fetch}) => {
+  return {posts: await (await fetch('/api/posts')).json()} as LoadResponse;
+}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,10 +1,10 @@
-import type {Post} from '$lib/postTypes';
+import type { Post } from '$lib/postTypes';
 import type { PageLoad } from './$types';
 
 type LoadResponse = {
-  posts: Post[]
-}
+  posts: Post[];
+};
 
-export const load: PageLoad = async ({fetch}) => {
-  return {posts: await (await fetch('/api/posts')).json()} as LoadResponse;
-}
+export const load: PageLoad = async ({ fetch }) => {
+  return { posts: await (await fetch('/api/posts')).json() } as LoadResponse;
+};

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -1,0 +1,33 @@
+import { json } from '@sveltejs/kit';
+import type { Post } from '$lib/postTypes';
+
+/// Gets all posts from the `src/posts` directory.
+///
+/// The `src/posts` directory is scanned for all `.md` files. Each file is
+/// expected to have a frontmatter section at the top of the file. The
+/// frontmatter is parsed and the file's slug is determined from the file's
+/// path. The slug is the file's path relative to the `src/posts` directory
+/// without the `.md` extension.
+///
+/// The posts are sorted by date in descending order (newest first).
+async function getAllPosts(): Promise<Post[]> {
+  const posts: Post[] = [];
+  const paths = import.meta.glob('/src/posts/*.md', { eager: true });
+  for (const path in paths) {
+    const file = paths[path];
+    const slug = path.split('/').at(-1)?.replace('.md', '');
+    if (file && typeof file === 'object' && 'metadata' in file && slug) {
+      const metadata = file.metadata as Omit<Post, 'slug'>;
+      const post = { ...metadata, slug } satisfies Post;
+      if (post.published) posts.push(post);
+    }
+  }
+  return posts.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
+}
+
+export async function GET() {
+  const posts = await getAllPosts();
+  return json(posts);
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,16 +1,17 @@
 import adapter from '@sveltejs/adapter-auto';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { mdsvex } from 'mdsvex';
+
+/** @type {import('mdsvex').MdsvexOptions} */
+const mdsvexOptions = {
+  extensions: ['.md'],
+};
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
-  // for more information about preprocessors
-  preprocess: vitePreprocess(),
-
+  extensions: ['.svelte', '.md'],
+  preprocess: [vitePreprocess(), mdsvex(mdsvexOptions)],
   kit: {
-    // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-    // If your environment is not supported or you settled on a specific environment, switch out the adapter.
-    // See https://kit.svelte.dev/docs/adapters for more information about adapters.
     adapter: adapter(),
   },
 };


### PR DESCRIPTION
Posts under `/src/posts/` which use the `.md` extension are now able to be parsed, or so it appears so. The frontmatter, defined using YAML, is verified to be able to be parsed. The frontmatter contains the following:

- `title: string;`
- `description: string;`
- `date: string;`
- `categories: Categories[];`
- `published: boolean;`

where `Categories` are currently defined as being of type `string`.

The index has been verified to be able to make a request to the API endpoint, retrieve the list, and be able to render it